### PR TITLE
Added a function that does not append the 'algo=' keyword to the http…

### DIFF
--- a/NiceHashClient.js
+++ b/NiceHashClient.js
@@ -248,6 +248,16 @@ class NiceHashClient {
     getProviderWorkersStats(addr, algo) {
         return this.getRequestPromise('stats.provider.workers', { addr, algo });
     }
+    
+    /**
+     * Get detailed stats for provider's workers (rigs).
+     * @param addr String - Provider's BTC Address
+     * @param algo Number - Algorithm marked with ID
+     * @return {*}
+     */
+    getAllProviderWorkersStats(addr) {
+        return this.getRequestPromise('stats.provider.workers', { addr });
+    }
 
     /**
      * Get all orders for certain algorithm. Refreshed every 30 seconds.

--- a/test/NiceHashClientTest.js
+++ b/test/NiceHashClientTest.js
@@ -99,6 +99,16 @@ context('NiceHashClient', () => {
                 });
             });
         });
+        
+        describe('getAllProviderWorkersStats', () => {
+            it('should get provider workers stats', function() {
+                const testAddress = `17a212wdrvEXWuipCV5gcfxdALfMdhMoqh`;
+                const testAlgo = 3;
+                return nh.getProviderWorkersStats(testAddress, testAlgo).then((response) => {
+                    response.body.uri.should.eql('/api?method=stats.provider.workers&addr=17a212wdrvEXWuipCV5gcfxdALfMdhMoqh');
+                });
+            });
+        });
 
         describe('getOrders', () => {
             it('should get all orders', function() {


### PR DESCRIPTION
…request. This makes it so that you can retrieve a list of all of the currently active workers.x